### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ gradio
 mdtex2html
 uvicorn
 fastapi
+sentencepiece


### PR DESCRIPTION
LlamaTokenizer requires the SentencePiece library but it was not found in your environment.