### PR TITLE
Add support for starchat template

### DIFF
--- a/src/llmtuner/extras/template.py
+++ b/src/llmtuner/extras/template.py
@@ -135,6 +135,17 @@ class Template:
                 sep="",
                 use_history=True
             )
+            
+        elif self.name == "starchat":
+            r"""
+            Supports: https://huggingface.co/HuggingFaceH4/starchat-beta
+            """
+            self._register_template(
+                prefix="<|system|>\n<|end|>\n",
+                prompt="<|user|>\n{query}<|end|>\n<|assistant|>\n",
+                sep="<|end|>\n",
+                use_history=True
+            )
 
         else:
             raise ValueError("Template {} does not exist.".format(self.name))


### PR DESCRIPTION

组织对话数据的方式：https://huggingface.co/blog/zh/starchat-alpha

![image](https://github.com/hiyouga/LLaMA-Efficient-Tuning/assets/111472355/e9bfb856-696a-476f-b802-50bbc1fc180a)

作者的项目非常棒！受益匪浅，我发现目前项目中的对话数据都是成对出现的，而且系统提示默认在第一句，这种方式是不是有一些不够完备，比如在调用接口时，用户第一次发送某个任务的具体描述，第二次发送问题（[chatgpt-next-web](https://github.com/Yidadaa/ChatGPT-Next-Web) 的面具里就是这种情况），这样 `messages` 里面连续两条消息 `role` 都是 `user`，如果采用上面博客中 `starchat` 的对话数据格式，就只需要根据角色将内容拼接起来，会不会更好一些呢。