### PR TITLE
set device_map as 'auto' to avoid CUDA OOM on multiple GPUs

### DIFF
--- a/src/llmtuner/tuner/core/loader.py
+++ b/src/llmtuner/tuner/core/loader.py
@@ -92,6 +92,8 @@ def load_model_and_tokenizer(
         is_mergeable = False
         config_kwargs["device_map"] = {"": int(os.environ.get("LOCAL_RANK", "0"))}
         logger.info("Quantizing model to {} bit.".format(model_args.quantization_bit))
+    else:
+        config_kwargs["device_map"] = 'auto'
 
     if model_args.checkpoint_dir is not None and finetuning_args.finetuning_type == "full":
         model_to_load = model_args.checkpoint_dir[0]


### PR DESCRIPTION
I added device_map = 'auto' as default for fine-tuning.

This change is raised because without this configuration, fine-tuning LLaMa2 using 'full' mode **on multiple GPUs from a single node** will result in CUDA out-of-memory error.

Here is an example:
Finetune LLaMa2 on four A100 (80G) from a single node.

The command I used:
```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 python src/train_bash.py     --stage sft     --model_name_or_path meta-llama/Llama-2-7b-hf     --do_train     --dataset my_dataset     --finetuning_type full     --output_dir /my/path/     --overwrite_cache     --per_device_train_batch_size 1     --gradient_accumulation_steps 1     --lr_scheduler_type cosine     --logging_steps 10     --save_steps 1000     --learning_rate 5e-5     --num_train_epochs 3.0     --plot_loss     --fp16
```

Before fixing this:
```bash
...
[INFO|trainer.py:386] 2023-07-26 21:51:22,014 >> You have loaded a model on multiple GPUs. `is_model_parallel` attribute will be force-set to `True` to avoid any unexpected behavior such as device placement mismatching.
07/26/2023 21:51:22 - WARNING - llmtuner.tuner.core.trainer - Previous log file in this folder will be deleted.
[INFO|trainer.py:1686] 2023-07-26 21:51:22,162 >> ***** Running training *****
[INFO|trainer.py:1687] 2023-07-26 21:51:22,162 >>   Num examples = 5,235
[INFO|trainer.py:1688] 2023-07-26 21:51:22,162 >>   Num Epochs = 3
[INFO|trainer.py:1689] 2023-07-26 21:51:22,162 >>   Instantaneous batch size per device = 1
[INFO|trainer.py:1691] 2023-07-26 21:51:22,162 >>   Training with DataParallel so batch size has been adjusted to: 4
[INFO|trainer.py:1692] 2023-07-26 21:51:22,162 >>   Total train batch size (w. parallel, distributed & accumulation) = 4
[INFO|trainer.py:1693] 2023-07-26 21:51:22,162 >>   Gradient Accumulation steps = 1
[INFO|trainer.py:1694] 2023-07-26 21:51:22,162 >>   Total optimization steps = 3,927
[INFO|trainer.py:1695] 2023-07-26 21:51:22,163 >>   Number of trainable parameters = 6,738,415,616
  0%|                                                                                                                                                                                                     | 0/3927 [00:00<?, ?it/s]
/users/****/anaconda3/envs/llama_etuning/lib/python3.10/site-packages/torch/nn/parallel/_functions.py:68: UserWarning: Was asked to gather along dimension 0, but all input tensors were scalars; will instead unsqueeze and return a vector.
  warnings.warn('Was asked to gather along dimension 0, but all '
Traceback (most recent call last):
  File "/users/****/LLaMA-Efficient-Tuning/src/train_bash.py", line 23, in <module>
    main()
  File "/users/****/LLaMA-Efficient-Tuning/src/train_bash.py", line 10, in main
    run_sft(model_args, data_args, training_args, finetuning_args)
  File "/users/****/LLaMA-Efficient-Tuning/src/llmtuner/tuner/sft/workflow.py", line 61, in run_sft
    train_result = trainer.train()
  File "/users/****/anaconda3/envs/llama_etuning/lib/python3.10/site-packages/transformers/trainer.py", line 1539, in train
    return inner_training_loop(
  File "/users/****/anaconda3/envs/llama_etuning/lib/python3.10/site-packages/transformers/trainer.py", line 1809, in _inner_training_loop
    tr_loss_step = self.training_step(model, inputs)
  File "/users/****/anaconda3/envs/llama_etuning/lib/python3.10/site-packages/transformers/trainer.py", line 2665, in training_step
    self.accelerator.backward(loss)
  File "/users/****/anaconda3/envs/llama_etuning/lib/python3.10/site-packages/accelerate/accelerator.py", line 1851, in backward
    self.scaler.scale(loss).backward(**kwargs)
  File "/users/****/anaconda3/envs/llama_etuning/lib/python3.10/site-packages/torch/_tensor.py", line 487, in backward
    torch.autograd.backward(
  File "/users/****/anaconda3/envs/llama_etuning/lib/python3.10/site-packages/torch/autograd/__init__.py", line 200, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
  File "/users/****/anaconda3/envs/llama_etuning/lib/python3.10/site-packages/torch/autograd/function.py", line 274, in apply
    return user_fn(self, *args)
  File "/users/****/anaconda3/envs/llama_etuning/lib/python3.10/site-packages/torch/utils/checkpoint.py", line 157, in backward
    torch.autograd.backward(outputs_with_grad, args_with_grad)
  File "/users/****/anaconda3/envs/llama_etuning/lib/python3.10/site-packages/torch/autograd/__init__.py", line 200, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 500.00 MiB (GPU 0; 79.15 GiB total capacity; 75.89 GiB already allocated; 264.38 MiB free; 77.60 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.  See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF
  0%|                                                                                                                                                                                                     | 0/3927 [00:12<?, ?it/s]
```

After adjusting this configuration, the model was fine-tuned correctly.