### PR TITLE
Feat: support for passing in generating parameters at prediction

### DIFF
--- a/src/llmtuner/tuner/sft/workflow.py
+++ b/src/llmtuner/tuner/sft/workflow.py
@@ -13,7 +13,7 @@ from llmtuner.tuner.sft.trainer import Seq2SeqPeftTrainer
 
 if TYPE_CHECKING:
     from transformers import Seq2SeqTrainingArguments, TrainerCallback
-    from llmtuner.hparams import ModelArguments, DataArguments, FinetuningArguments
+    from llmtuner.hparams import ModelArguments, DataArguments, FinetuningArguments, GeneratingArguments
 
 
 def run_sft(
@@ -21,6 +21,7 @@ def run_sft(
     data_args: "DataArguments",
     training_args: "Seq2SeqTrainingArguments",
     finetuning_args: "FinetuningArguments",
+    generating_args: "GeneratingArguments",
     callbacks: Optional[List["TrainerCallback"]] = None
 ):
     dataset = get_dataset(model_args, data_args)
@@ -51,11 +52,11 @@ def run_sft(
 
     # Keyword arguments for `model.generate`
     gen_kwargs = {
-        "do_sample": True,
-        "top_p": 0.7,
+        "do_sample": generating_args.do_sample,
+        "top_p": generating_args.top_p,
         "max_new_tokens": data_args.max_target_length + 1,
-        "temperature": 0.95,
-        "logits_processor": get_logits_processor()
+        "temperature": generating_args.temperature,
+        "logits_processor": get_logits_processor(),
     }
 
     # Training

--- a/src/llmtuner/tuner/tune.py
+++ b/src/llmtuner/tuner/tune.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from llmtuner.extras.callbacks import LogCallback
-from llmtuner.tuner.core import get_train_args, load_model_and_tokenizer
+from llmtuner.tuner.core import get_train_args, load_model_and_tokenizer, get_infer_args
 from llmtuner.tuner.pt import run_pt
 from llmtuner.tuner.sft import run_sft
 from llmtuner.tuner.rm import run_rm
@@ -13,14 +13,15 @@ if TYPE_CHECKING:
 
 def run_exp(args: Optional[Dict[str, Any]] = None, callbacks: Optional[List["TrainerCallback"]] = None):
     model_args, data_args, training_args, finetuning_args, general_args = get_train_args(args)
+    _, _, _, generating_args = get_infer_args(args)
     callbacks = [LogCallback()] if callbacks is None else callbacks
 
     if general_args.stage == "pt":
-        run_pt(model_args, data_args, training_args, finetuning_args, callbacks)
+        run_pt(model_args, data_args, training_args, finetuning_args, generating_args, callbacks)
     elif general_args.stage == "sft":
-        run_sft(model_args, data_args, training_args, finetuning_args, callbacks)
+        run_sft(model_args, data_args, training_args, finetuning_args, generating_args, callbacks)
     elif general_args.stage == "rm":
-        run_rm(model_args, data_args, training_args, finetuning_args, callbacks)
+        run_rm(model_args, data_args, training_args, finetuning_args, generating_args, callbacks)
     elif general_args.stage == "ppo":
         run_ppo(model_args, data_args, training_args, finetuning_args, callbacks)
 


### PR DESCRIPTION
Example:

```bash
CUDA_VISIBLE_DEVICES=0 python src/train_bash.py \
    --stage sft \
    --temperature 0.8 \
    --top_p 0.5 \
    --model_name_or_path path_to_your_model \
    --do_predict \
    --dataset alpaca_gpt4_zh \
    --template default \
    --finetuning_type lora \
    --checkpoint_dir path_to_checkpoint \
    --output_dir path_to_predict_result \
    --per_device_eval_batch_size 8 \
    --max_samples 100
```