### PR TITLE
Fix PPO replace_model loading wrong default parameters.

### DIFF
--- a/src/llmtuner/tuner/ppo/utils.py
+++ b/src/llmtuner/tuner/ppo/utils.py
@@ -10,8 +10,8 @@ if TYPE_CHECKING:
 def replace_model(model: "AutoModelForCausalLMWithValueHead", target: Literal["default", "reward"]) -> None:
     if target == "reward": # save default head temporarily
         valuehead_state_dict = model.v_head.state_dict()
-        setattr(model, "default_head_weight", valuehead_state_dict["summary.weight"])
-        setattr(model, "default_head_bias", valuehead_state_dict["summary.bias"])
+        setattr(model, "default_head_weight", valuehead_state_dict["summary.weight"].clone())
+        setattr(model, "default_head_bias", valuehead_state_dict["summary.bias"].clone())
 
     model.pretrained_model.set_adapter(target) # set the LoRA adapter to be active
     model.v_head.load_state_dict({


### PR DESCRIPTION
Fix parameters load error.

The method `torch.nn.Module.state_dict` 's return object is a shallow copy. It contains references to the module’s parameters and buffers. Use deep copy to avoid loading wrong default parameters.
![image](https://github.com/hiyouga/LLaMA-Efficient-Tuning/assets/96833021/2bfd9d78-785c-4c9a-90d7-aea873fecaba)
