### PR TITLE
Add Ascend NPU support

### DIFF
--- a/src/llmtuner/tuner/core/loader.py
+++ b/src/llmtuner/tuner/core/loader.py
@@ -13,7 +13,7 @@ from transformers import (
     PreTrainedModel,
     PreTrainedTokenizerBase
 )
-from transformers.utils import check_min_version
+from transformers.utils import check_min_version, is_torch_npu_available
 from transformers.utils.versions import require_version
 from trl import AutoModelForCausalLMWithValueHead
 
@@ -215,7 +215,10 @@ def load_model_and_tokenizer(
     # Prepare model for inference
     if not is_trainable:
         model.requires_grad_(False) # fix all model params
-        infer_dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16 # detect cuda capability
+        if is_torch_npu_available():
+            infer_dtype = torch.float16
+        else:
+            infer_dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16 # detect cuda capability
         model = model.to(infer_dtype) if model_args.quantization_bit is None else model
 
     trainable_params, all_param = count_parameters(model)


### PR DESCRIPTION
## What does this PR do?

This PR integrates Ascend NPU hardware capabilities into the LLaMA-Efficient-Tuning, and enables users to leverage the NPUs for training, inference and serving of LLMs.

[Ascend NPU](https://www.hiascend.com/en/) is an AI processor that support AI frameworks like PyTorch, TensorFlow, which has already integrated by [huggingface](https://github.com/huggingface/accelerate/commit/c33adecc9f92808cbaeb0d34928e52e34180f964), [deepspeed](https://github.com/microsoft/DeepSpeed/commit/23a11a39510e2aefb48236e3d2672a7dcbfc42a3) and others popular LLM related software and tools.

As mentioned above, Ascend NPU already supports libraries such as Transformers/Accelerate, so you can refer to the fine-tuning instructions in the README to perform LLM fine-tuning tasks directly on Ascend NPU.

The model export phase requires adding Ascend NPU adaptation logic, which is addressed in this patch.